### PR TITLE
[Narrator] prompt to describe the image like David Attenborough for increased complex descriptors.

### DIFF
--- a/narrator.py
+++ b/narrator.py
@@ -43,7 +43,7 @@ def generate_new_line(base64_image):
         {
             "role": "user",
             "content": [
-                {"type": "text", "text": "Describe this image"},
+                {"type": "text", "text": "Describe this image as if you David Attenborough"},
                 {
                     "type": "image_url",
                     "image_url": f"data:image/jpeg;base64,{base64_image}",


### PR DESCRIPTION
### Summary
- Updated to the narrator GPT prompt to explicitly have it describe the image as David Attenborough for increased complex descriptors (and humor). 