### PR TITLE
[dotenv] module added and README updated with information on how to use. 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Required variables:
+export OPENAI_API_KEY=
+export ELEVENLABS_API_KEY=
+export ELEVENLABS_VOICE_ID=
+
+# Optional variables:
+export ELEVENLABS_STREAMING=
+export PHOTOBOOTH_MODE=

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# David Attenborough narrates your life.
+# David Attenborough narrates your life
 
 https://twitter.com/charliebholtz/status/1724815159590293764
 
@@ -32,12 +32,6 @@ Make a new voice in Eleven and get the voice id of that voice using their [get v
 export ELEVENLABS_VOICE_ID=<voice-id>
 ```
 
-### Script
-
-Alternative to running the commands above individually, one can use the `setup.sh` script to facilitate getting the two required shell envs ready to rock by updating the environment variable values in `setup.sh` and executing the script.
-
-_Note: may have to manually run `source source venv/bin/activate` afterwards depending on shell env._
-
 ## Run it!
 
 In on terminal, run the webcam capture:
@@ -53,6 +47,18 @@ python narrator.py
 ```
 
 ## Options
+
+### Setup
+
+#### Script
+
+Alternative to running the [Setup](#setup) commands above individually, one can use the `setup.sh` script to facilitate getting the two required shell envs ready to rock.
+
+_Note: may have to manually run `source source venv/bin/activate` afterwards depending on shell env._
+
+#### Dotenv
+
+One can set the environment variables via the `.env` file, which is read every time the process starts. It is recommended to copy the `.env.example` file and rename to `.env`.
 
 ### Streaming
 

--- a/narrator.py
+++ b/narrator.py
@@ -3,11 +3,15 @@ import errno
 import os
 import time
 
+from dotenv import load_dotenv
 from elevenlabs import generate, play, set_api_key, stream
 from openai import OpenAI
 from pynput import (  # Using pynput to listen for a keypress instead of native keyboard module which was requiring admin privileges
     keyboard,
 )
+
+# import environment variables from .env file
+load_dotenv()
 
 client = OpenAI()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ pydantic==2.4.2
 pydantic_core==2.10.1
 Pygments==2.16.1
 pynput==1.7.6
+python-dotenv==1.0.0
 requests==2.31.0
 simpleaudio==1.0.4
 six==1.16.0

--- a/setup.sh
+++ b/setup.sh
@@ -4,15 +4,10 @@
 python3 -m pip install virtualenv
 python3 -m virtualenv venv
 
-# source the virtual environment
+# source the virtual environment to install dependencies
 source venv/bin/activate
 
 # install the dependencies
 pip install -r requirements.txt
 
-# set the environment variables
-export ELEVENLABS_VOICE_ID=
-export OPENAI_API_KEY=
-export ELEVENLABS_API_KEY=
-
-export ELEVENLABS_STREAMING=false
+echo -e "\n\n\nSetup complete. Run $(source venv/bin/activate) to activate the virtual environment.\n\nAlso, please ensure your environment variables are set correctly in the .env file."


### PR DESCRIPTION
### Summary
- included `python_dotenv` module in `requirements.txt` for ease of env var definitions via the `.env` file. 
- README updated with information on how to use and `.env.example` file provided